### PR TITLE
specify utf-8 encoding

### DIFF
--- a/ui_trt.py
+++ b/ui_trt.py
@@ -815,6 +815,7 @@ def on_ui_tabs():
                 with open(
                     os.path.join(os.path.dirname(os.path.abspath(__file__)), "info.md"),
                     "r",
+                    encoding='utf-8',
                 ) as f:
                     trt_info = gr.Markdown(elem_id="trt_info", value=f.read())
 


### PR DESCRIPTION
fix
```shell
*** Error executing callback ui_tabs_callback for C:\GitHub\stable-diffusion-webui\extensions\Stable-Diffusion-WebUI-TensorRT\scripts\trt.py
    Traceback (most recent call last):
      File "C:\GitHub\stable-diffusion-webui\modules\script_callbacks.py", line 166, in ui_tabs_callback
        res += c.callback() or []
      File "C:\GitHub\stable-diffusion-webui\extensions\Stable-Diffusion-WebUI-TensorRT\ui_trt.py", line 819, in on_ui_tabs
        trt_info = gr.Markdown(elem_id="trt_info", value=f.read())
    UnicodeDecodeError: 'cp932' codec can't decode byte 0x92 in position 387: illegal multibyte sequence
---
```
Windows is an annoying OS, the default file encodeing will change base on OS user language

the fix is to specify utf-8 encoding
