### PR TITLE
print(logging_history) as as opposed to yield

### DIFF
--- a/ui_trt.py
+++ b/ui_trt.py
@@ -85,7 +85,7 @@ def export_unet_to_trt(
         logging_history = log_md(
             logging_history, "FP16 has been disabled because your GPU does not support it."
         )
-        yield logging_history
+        print(logging_history)
 
     unet_hidden_dim = shared.sd_model.model.diffusion_model.in_channels
     if unet_hidden_dim == 9:
@@ -98,7 +98,7 @@ def export_unet_to_trt(
     logging_history = log_md(
         logging_history, f"Exporting {model_name} to TensorRT", prefix="###"
     )
-    yield logging_history
+    print(logging_history)
 
     timing_cache = modelmanager.get_timing_cache()
 
@@ -150,7 +150,7 @@ def export_unet_to_trt(
 
     if not os.path.exists(onnx_path):
         logging_history = log_md(logging_history, "No ONNX file found. Exporting ONNX…")
-        yield logging_history
+        print(logging_history)
         export_onnx(
             onnx_path,
             modelobj,
@@ -158,7 +158,7 @@ def export_unet_to_trt(
             diable_optimizations=diable_optimizations,
         )
         logging_history = log_md(logging_history, "Exported to ONNX.")
-        yield logging_history
+        print(logging_history)
 
     trt_engine_filename, trt_path = modelmanager.get_trt_path(
         model_name, model_hash, profile, static_shapes
@@ -169,7 +169,7 @@ def export_unet_to_trt(
             logging_history,
             "Building TensorRT engine... This can take a while, please check the progress in the terminal.",
         )
-        yield logging_history
+        print(logging_history)
         gc.collect()
         torch.cuda.empty_cache()
         ret = export_trt(
@@ -180,12 +180,12 @@ def export_unet_to_trt(
             use_fp16=not use_fp32,
         )
         if ret:
-            yield logging_history + "\n --- \n ## Export Failed due to unknown reason. See shell for more information. \n"
+            print(logging_history + "\n --- \n ## Export Failed due to unknown reason. See shell for more information. \n")
             return
         logging_history = log_md(
             logging_history, "TensorRT engines has been saved to disk."
         )
-        yield logging_history
+        print(logging_history)
         modelmanager.add_entry(
             model_name,
             model_hash,
@@ -203,9 +203,9 @@ def export_unet_to_trt(
             logging_history,
             "TensorRT engine found. Skipping build. You can enable Force Export in the Advanced Settings to force a rebuild if needed.",
         )
-        yield logging_history
+        print(logging_history)
 
-    yield logging_history + "\n --- \n ## Exported Successfully \n"
+    print(logging_history + "\n --- \n ## Exported Successfully \n")
 
 
 def export_lora_to_trt(lora_name, force_export):
@@ -217,7 +217,7 @@ def export_lora_to_trt(lora_name, force_export):
         logging_history = log_md(
             logging_history, "FP16 has been disabled because your GPU does not support it."
         )
-        yield logging_history
+        print(logging_history)
     unet_hidden_dim = shared.sd_model.model.diffusion_model.in_channels
     if unet_hidden_dim == 9:
         is_inpaint = True
@@ -262,7 +262,7 @@ def export_lora_to_trt(lora_name, force_export):
 
     if not os.path.exists(onnx_lora_path):
         logging_history = log_md(logging_history, "No ONNX file found. Exporting ONNX…")
-        yield logging_history
+        print(logging_history)
         export_onnx(
             onnx_lora_path,
             modelobj,
@@ -273,7 +273,7 @@ def export_lora_to_trt(lora_name, force_export):
             lora_path=lora_model["filename"],
         )
         logging_history = log_md(logging_history, "Exported to ONNX.")
-        yield logging_history
+        print(logging_history)
 
     trt_lora_name = onnx_lora_filename.replace(".onnx", ".trt")
     trt_lora_path = os.path.join(TRT_MODEL_DIR, trt_lora_name)
@@ -281,7 +281,7 @@ def export_lora_to_trt(lora_name, force_export):
     available_trt_unet = modelmanager.available_models()
     if len(available_trt_unet[base_name]) == 0:
         logging_history = log_md(logging_history, "Please export the base model first.")
-        yield logging_history
+        print(logging_history)
     trt_base_path = os.path.join(
         TRT_MODEL_DIR, available_trt_unet[base_name][0]["filepath"]
     )
@@ -293,12 +293,12 @@ def export_lora_to_trt(lora_name, force_export):
         logging_history = log_md(
             logging_history, "No TensorRT engine found. Building..."
         )
-        yield logging_history
+        print(logging_history)
         engine = Engine(trt_base_path)
         engine.load()
         engine.refit(onnx_base_path, onnx_lora_path, dump_refit_path=trt_lora_path)
         logging_history = log_md(logging_history, "Built TensorRT engine.")
-        yield logging_history
+        print(logging_history)
 
         modelmanager.add_lora_entry(
             base_name,
@@ -309,7 +309,7 @@ def export_lora_to_trt(lora_name, force_export):
             0,
             unet_hidden_dim,
         )
-    yield logging_history + "\n --- \n ## Exported Successfully \n"
+    print(logging_history + "\n --- \n ## Exported Successfully \n")
 
 
 def export_default_unet_to_trt():


### PR DESCRIPTION
https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions/pull/205#issuecomment-1766334220
this is a hotfix, consider it is just a code sample that will "suppress" the issue
this makes the user interface less pretty and makes the logs a bit unreadable leaving behind a currently useless output element
but at the very least it "makes it work" function over form

---

one major issue that I'm being experiencing randomly is this
it almost appear every time I try to export an engine
sometimes when this happens the process completely holds other times it continues I managed to get one successfully completed and use it to run sd with trt and I can say that it is significantly faster
but most of the time my engine fails to export, making this almost unusable
```shell
Building TensorRT engine for B:\GitHub\stable-diffusion-webui\models\Unet-onnx\Anime_Anything-V3.0_Anything-V3.0-fp16_Anything-V3.0-pruned-fp16_38c1ebe3.onnx
: B:\GitHub\stable-diffusion-webui\models\Unet-trt\Anime_Anything-V3.0_Anything-V3.0-fp16_Anything-V3.0-pruned-fp16_38c1ebe3_cc86_sample=1x4x64x64+2x4x64x64+
8x4x96x96-timesteps=1+2+8-encoder_hidden_states=1x77x768+2x77x768+8x154x768.trt
ERROR:asyncio:Exception in callback H11Protocol.timeout_keep_alive_handler()
handle: <TimerHandle when=355099.875 H11Protocol.timeout_keep_alive_handler()>
Traceback (most recent call last):
  File "B:\GitHub\stable-diffusion-webui\venv\lib\site-packages\h11\_state.py", line 249, in _fire_event_triggered_transitions
    new_state = EVENT_TRIGGERED_TRANSITIONS[role][state][event_type]
KeyError: <class 'h11._events.ConnectionClosed'>

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\Programs\Python\3.10.6\lib\asyncio\events.py", line 80, in _run
    self._context.run(self._callback, *self._args)
  File "B:\GitHub\stable-diffusion-webui\venv\lib\site-packages\uvicorn\protocols\http\h11_impl.py", line 363, in timeout_keep_alive_handler
    self.conn.send(event)
  File "B:\GitHub\stable-diffusion-webui\venv\lib\site-packages\h11\_connection.py", line 468, in send
    data_list = self.send_with_data_passthrough(event)
  File "B:\GitHub\stable-diffusion-webui\venv\lib\site-packages\h11\_connection.py", line 493, in send_with_data_passthrough
    self._process_event(self.our_role, event)
  File "B:\GitHub\stable-diffusion-webui\venv\lib\site-packages\h11\_connection.py", line 242, in _process_event
    self._cstate.process_event(role, type(event), server_switch_event)
  File "B:\GitHub\stable-diffusion-webui\venv\lib\site-packages\h11\_state.py", line 238, in process_event
    self._fire_event_triggered_transitions(role, event_type)
  File "B:\GitHub\stable-diffusion-webui\venv\lib\site-packages\h11\_state.py", line 251, in _fire_event_triggered_transitions
    raise LocalProtocolError(
h11._util.LocalProtocolError: can't handle event type ConnectionClosed when role=SERVER and state=SEND_RESPONSE
```

the engines does seem to be generated (saved to disk) but the profiles are just not created so webui doesn't see it

### Cause and patch fix
as far that I can see this is caused by `yield logging_history`
I've made an edit to replace all  `yield logging_history` with `print(logging_history)` and it seems to work fine