### PR TITLE
trt profile as one markdown

### DIFF
--- a/ui_trt.py
+++ b/ui_trt.py
@@ -822,23 +822,19 @@ def on_ui_tabs():
             with gr.Accordion("Output", open=True):
                 trt_result = gr.Markdown(elem_id="trt_result", value="")
 
-        with gr.Column(variant="panel"):
-            with gr.Row(equal_height=True, variant="compact"):
-                button_refresh_profiles = ToolButton(value=refresh_symbol, elem_id="trt_refresh_profiles", visible=True)
-                profile_header_md = gr.Markdown(
-                    value=f"## Available TensorRT Engine Profiles"
-                )
-            engines_md = engine_profile_card()
-            for model, profiles in engines_md.items():
-                with gr.Row(equal_height=False):
-                    row_name = model + " ({} Profiles)".format(len(profiles))
-                    with gr.Accordion(row_name, open=False):
-                        out_string = ""
-                        for i, profile in enumerate(profiles):
-                            out_string += f"#### Profile {i} \n"
-                            out_string += profile
-                            out_string += "\n\n"
-                        gr.Markdown(elem_id=f"trt_{model}_{i}", value=out_string)
+        def get_trt_profiles_markdown():
+            profiles_md_string = "<details><summary>Available TensorRT Engine Profiles</summary>\n\n"
+            for model, profiles in engine_profile_card().items():
+                profiles_md_string += f"<details><summary>{model} ({len(profiles)} Profiles)</summary>\n\n"
+                for i, profile in enumerate(profiles):
+                    profiles_md_string += f"#### Profile {i} \n{profile}\n\n"
+                profiles_md_string += "</details>\n"
+            profiles_md_string += "</details>\n"
+            return profiles_md_string
+
+        button_refresh_profiles = ToolButton(value=refresh_symbol, elem_id="trt_refresh_profiles", visible=True)
+        trt_profiles_markdown = gr.Markdown(elem_id=f"trt_profiles_markdown", value=get_trt_profiles_markdown())
+        button_refresh_profiles.click(lambda: gr.Markdown.update(value=get_trt_profiles_markdown()), outputs=[trt_profiles_markdown])
 
         button_export_unet.click(
             export_unet_to_trt,
@@ -890,13 +886,12 @@ def on_ui_tabs():
             outputs=[trt_result],
         )
 
-        
         # TODO Dynamically update available profiles. Not possible with gradio?!
-        button_refresh_profiles.click(
-                fn=shared.state.request_restart,
-                _js='restart_reload',
-                inputs=[],
-                outputs=[],
-        )
+        # button_refresh_profiles.click(
+        #         fn=shared.state.request_restart,
+        #         _js='restart_reload',
+        #         inputs=[],
+        #         outputs=[],
+        # )
 
     return [(trt_interface, "TensorRT", "tensorrt")]

--- a/ui_trt.py
+++ b/ui_trt.py
@@ -886,12 +886,4 @@ def on_ui_tabs():
             outputs=[trt_result],
         )
 
-        # TODO Dynamically update available profiles. Not possible with gradio?!
-        # button_refresh_profiles.click(
-        #         fn=shared.state.request_restart,
-        #         _js='restart_reload',
-        #         inputs=[],
-        #         outputs=[],
-        # )
-
     return [(trt_interface, "TensorRT", "tensorrt")]


### PR DESCRIPTION
combining all trt profile into a single markdown, and make the refresh button update the markdown

read out in the UI is just the wrong way to go

this is just a simple example on how it can be done, I didn't spend too much time on it, I don't expect this to get merged

if you want to go full out and want to have absolutely full control on the entire interface then you should use HTML element instead

some other examples on using HTML can be found in webUI such as the extensions tab we generate custom tables
extra networks tab is also HTML we generate cards with images and are able to refresh them

![image](https://github.com/NVIDIA/Stable-Diffusion-WebUI-TensorRT/assets/40751091/f5851dce-42d0-4235-9732-a05d1e8d3ae8)

https://github.com/NVIDIA/Stable-Diffusion-WebUI-TensorRT/assets/40751091/539082cd-8406-46a8-80f5-ebcc7a2d1f20
