### PR TITLE
remove shared imoprt quick_setting form installer

### DIFF
--- a/install.py
+++ b/install.py
@@ -1,5 +1,5 @@
 import launch
-from modules import shared
+
 
 def install():
     if not launch.is_installed("tensorrt"):
@@ -19,12 +19,5 @@ def install():
         launch.run_pip("install protobuf==3.20.2", "protobuf", live=True)
         launch.run_pip('install onnx-graphsurgeon --extra-index-url https://pypi.ngc.nvidia.com', "onnx-graphsurgeon", live=True)
 
-    if shared.opts is None:
-        print("UI Config not initialized")
-        return 
-    
-    if "sd_unet" not in shared.opts["quicksettings_list"]:
-        shared.opts["quicksettings_list"].append("sd_unet")
-        shared.opts.save(shared.config_filename)
  
 install()


### PR DESCRIPTION
remove shared imoprt quick_setting form installer

reason 1
trying to modify `quicksettings_list` in install it doesn't work
it will always be "UI Config not initialized"
the installer does not have access to which configuration file is supposed to be used
so we can't even directly read the json file

reason 2
modules.shared is it extremely heavy import, and as installer is run on every launch, it can significantly slow down webui launch

| with shared | without shared |
|--------|--------|
| ![image](https://github.com/NVIDIA/Stable-Diffusion-WebUI-TensorRT/assets/40751091/ed7e72aa-a7c1-4e58-95c8-748cfc070a9f) | ![image](https://github.com/NVIDIA/Stable-Diffusion-WebUI-TensorRT/assets/40751091/3163ded8-2476-4c76-b332-46e72919fa8d) | 

> tip: the startup profiler can be found at the footer of webUI

whether or not to add `sd_unet` to the `quicksettings_list` for the user is a debatable question
on the one hand most people might consider it essential when using TRT, but others found it quote ["intrusive"](https://github.com/AUTOMATIC1111/stable-diffusion-webui-extensions/pull/205#issuecomment-1765882938)
also people might have special use cases, so at the very least it should be optional

if you wish to make modifications to `quicksettings_list`, I believe `before_ui_callback` is the place to do it
https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/5ef669de080814067961f28357256e8fe27544f4/modules/script_callbacks.py#L277
use `on_before_ui(callback)` to add a function there
https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/5ef669de080814067961f28357256e8fe27544f4/modules/script_callbacks.py#L464
which would get executed at
https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/5ef669de080814067961f28357256e8fe27544f4/webui.py#L61