### PR TITLE
fix: installed check for onnx-graphsurgeon

### DIFF
--- a/install.py
+++ b/install.py
@@ -14,7 +14,7 @@ def install():
         launch.run_pip("install polygraphy --extra-index-url https://pypi.ngc.nvidia.com", "polygraphy", live=True)
     
     # ONNX GS
-    if not launch.is_installed("onnx-graphsurgeon"):
+    if not launch.is_installed("onnx_graphsurgeon"):
         print("GS is not installed! Installing...")
         launch.run_pip("install protobuf==3.20.2", "protobuf", live=True)
         launch.run_pip('install onnx-graphsurgeon --extra-index-url https://pypi.ngc.nvidia.com', "onnx-graphsurgeon", live=True)


### PR DESCRIPTION
Apply the package import name to `launch.is_installed()` instead of the pip package name.

## Problem

The following message is displayed every time at start up.

```
GS is not installed! Installing...
Installing protobuf
Installing onnx-graphsurgeon
```

## Expected

If the package is already installed, the above message will not be displayed.