### PR TITLE
fix: overwrite min, max values with opt value if static shapes

### DIFF
--- a/ui_trt.py
+++ b/ui_trt.py
@@ -114,6 +114,9 @@ def export_unet_to_trt(
     max_textlen = (token_count_max // 75) * 77
     if static_shapes:
         min_textlen = max_textlen = opt_textlen
+        batch_min = batch_max = batch_opt
+        height_min = height_max = height_opt
+        width_min = width_max = width_opt
 
     if shared.sd_model.is_sdxl:
         pipeline = PIPELINE_TYPE.SD_XL_BASE


### PR DESCRIPTION
## Problem

If `Use static shapes` is enabled and optimal values are changed, the following error occurs.

```
[E] 4: Specified optimization profiles must satisfy MIN<=OPT<=MAX.
[!] Profile is not valid, please provide profile data.
```

## Expected

No error occurs.