### PR TITLE
fix: uninstall scripts

### DIFF
--- a/install.py
+++ b/install.py
@@ -1,21 +1,25 @@
 import launch
-from importlib_metadata import version
+import sys
+from importlib_metadata import version, PackageNotFoundError
+
+python = sys.executable
 
 def install():
     if launch.is_installed("tensorrt"):
         if not version("tensorrt") == "9.0.1.post11.dev4":
-            launch.run(["python","-m","pip","uninstall","-y","tensorrt"], "removing old version of tensorrt")
+            launch.run(f'"{python}" -m pip uninstall -y tensorrt', "removing old version of tensorrt")
         
     
     if not launch.is_installed("tensorrt"):
         print("TensorRT is not installed! Installing...")
         launch.run_pip("install nvidia-cudnn-cu11==8.9.4.25 --no-cache-dir", "nvidia-cudnn-cu11")
         launch.run_pip("install --pre --extra-index-url https://pypi.nvidia.com tensorrt==9.0.1.post11.dev4 --no-cache-dir", "tensorrt", live=True)
-        launch.run(["python","-m","pip","uninstall","-y","nvidia-cudnn-cu11"], "removing nvidia-cudnn-cu11")
-        
-    if launch.is_installed("nvidia-cudnn-cu11"):
+
+    try:
         if version("nvidia-cudnn-cu11") == "8.9.4.25":
-            launch.run(["python","-m","pip","uninstall","-y","nvidia-cudnn-cu11"], "removing nvidia-cudnn-cu11")
+            launch.run(f'"{python}" -m pip uninstall -y nvidia-cudnn-cu11', "removing nvidia-cudnn-cu11")
+    except PackageNotFoundError:
+        pass # nvidia-cudnn-cu11 is not installed
 
     # Polygraphy	
     if not launch.is_installed("polygraphy"):


### PR DESCRIPTION
## Problem

- `pip uninstall` is not executed and the startup process stops at that line.
- cuDNN package installation check is always false.

## Solution

Specify a string instead an array to the `launch.run()`.
If an an array is specified, a python shell will start.

`launch.is_installed()` cannot check pip package names, so use `try` and `version()`.