### PR TITLE
Update README.md - one spelling mistake

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Each preset can be adjusted with the “Advanced Settings” option. More detail
 ### Common Issues/Limitations
 
 **HIRES FIX:** If using the hires.fix option in Automatic1111 you must build engines that match both the starting and ending resolutions. For instance, if initial size is `512 x 512` and hires.fix upscales to `1024 x 1024`, you must either generate two engines, one at 512 and one at 1024, or generate a single dynamic engine that covers the whole range.
-Having two seperate engines will heavily impact performance at the moment. Stay tuned for updates.
+Having two separate engines will heavily impact performance at the moment. Stay tuned for updates.
 
 **Resolution:** When generating images the resolution needs to be a multiple of 64. This applies to hires.fix as well, requiring the low and high-res to be divisible by 64.
 


### PR DESCRIPTION
I have noticed one grammatical mistake in **README** inside section "**Common issues/Limitations**"

**seperate -> separate**

Screenshot-

![Screenshot (136)](https://github.com/NVIDIA/Stable-Diffusion-WebUI-TensorRT/assets/115995339/3f8af504-cba6-43d8-9fd7-3901fa8fc663)
