### PR TITLE
Potential fix for #180

### DIFF
--- a/models.py
+++ b/models.py
@@ -810,6 +810,7 @@ class OAIUNet(BaseModel):
         verbose=True,
         fp16=False,
         max_batch_size=16,
+        text_minlen=77,
         text_maxlen=77,
         text_optlen=77,
         unet_dim=4,
@@ -828,6 +829,7 @@ class OAIUNet(BaseModel):
         )
         self.unet_dim = unet_dim
         self.controlnet = controlnet
+        self.text_minlen = text_minlen
         self.text_optlen = text_optlen
 
     def get_input_names(self):
@@ -896,7 +898,7 @@ class OAIUNet(BaseModel):
                 ],
                 "timesteps": [(min_batch,), (opt_batch,), (max_batch,)],
                 "encoder_hidden_states": [
-                    (min_batch, self.text_optlen, self.embedding_dim),
+                    (min_batch, self.text_minlen, self.embedding_dim),
                     (opt_batch, self.text_optlen, self.embedding_dim),
                     (max_batch, self.text_maxlen, self.embedding_dim),
                 ],
@@ -1034,6 +1036,7 @@ def make_OAIUNet(
     device,
     verbose,
     max_batch_size,
+    text_minlen,
     text_optlen,
     text_maxlen,
     controlnet=None,
@@ -1045,6 +1048,7 @@ def make_OAIUNet(
         device=device,
         verbose=verbose,
         max_batch_size=max_batch_size,
+        text_minlen=text_minlen,
         text_optlen=text_optlen,
         text_maxlen=text_maxlen,
         unet_dim=(9 if pipeline.is_inpaint() else 4),

--- a/models.py
+++ b/models.py
@@ -317,7 +317,7 @@ class BaseModel:
             return (opt_batch, opt_batch, opt_batch)
         elif self.text_maxlen > 77 and not static_batch:
             if self.text_optlen > 77:
-                return (min_batch, opt_batch, max_batch * 2)
+                return (min_batch, opt_batch * 2, max_batch * 2)
             return (min_batch, opt_batch * 2, max_batch * 2)
         else:
             raise Exception("Uncovered case in get_batch_dim")

--- a/ui_trt.py
+++ b/ui_trt.py
@@ -109,6 +109,7 @@ def export_unet_to_trt(
             "cuda",
             False,
             batch_max,
+            min_textlen,
             opt_textlen,
             max_textlen,
             controlnet,


### PR DESCRIPTION
#180 
Potentially fixes the problem where a token optimal length over the minimal value fails when the engine also triggers the onnx export.

I just adjusted the `get_batch_dim` so, when called with the default engine generation parameters, with the only difference being the optimal and maximal token length being increased, it produces the default engine but with optimal and max token length raised.

And I pass the token_min_length parameter from the ui that was abandoned through the objects so the token_min_length can actually be set. Right now min_length and opt_length are just the same value (opt_length).