### PR TITLE
Fixes crashes cause by lora checkpoint configs missing sd version

### DIFF
--- a/ui_trt.py
+++ b/ui_trt.py
@@ -268,7 +268,10 @@ def get_lora_checkpoints():
         if os.path.exists(config_file):
             with open(config_file, "r") as f:
                 config = json.load(f)
-            version = SDVersion.from_str(config["sd version"])
+            try:
+                version = SDVersion.from_str(config["sd version"])
+            except:
+                version = SDVersion.Unknown
 
         else:
             version = SDVersion.Unknown


### PR DESCRIPTION
During the initial Lora loading process, if a config for a specified ```.safetensor``` file does not contain the property ```"sd version"```, the plugin crashes and does not show the trt tab. 

fixes the issue by inferencing the Lora version as unknown