### PR TITLE
Fix AttributeError when accessing profile_idx of NoneType

### DIFF
--- a/scripts/trt.py
+++ b/scripts/trt.py
@@ -299,7 +299,7 @@ class TensorRTScript(scripts.Script):
         if self.torch_unet:
             return super().process_batch(p, *args, **kwargs)
 
-        if self.idx != sd_unet.current_unet.profile_idx:
+        if sd_unet.current_unet is not None and self.idx != sd_unet.current_unet.profile_idx:
             sd_unet.current_unet.profile_idx = self.idx
             sd_unet.current_unet.switch_engine()
 


### PR DESCRIPTION
This PR addresses an issue that was causing an AttributeError when trying to access the profile_idx attribute of sd_unet.current_unet, which was None.

The error was as follows:

```
*** Error running process_batch: C:\Users\uesrname\stable-diffusion-webui\extensions\Stable-Diffusion-WebUI-TensorRT\scripts\trt.py
    Traceback (most recent call last):
      File "C:\Users\username\stable-diffusion-webui\modules\scripts.py", line 742, in process_batch
        script.process_batch(p, *script_args, **kwargs)
      File "C:\Users\username\stable-diffusion-webui\extensions\Stable-Diffusion-WebUI-TensorRT\scripts\trt.py", line 302, in process_batch
        if self.idx != sd_unet.current_unet.profile_idx:
    AttributeError: 'NoneType' object has no attribute 'profile_idx'
```

This error occurred when sd_unet.current_unet was None. Trying to reference sd_unet.current_unet.profile_idx resulted in an AttributeError because the NoneType object does not have a profile_idx attribute.

To fix this issue, I added a condition to check if sd_unet.current_unet is not None before trying to access its profile_idx attribute. This prevents the AttributeError from being raised when sd_unet.current_unet is None.

Please review this fix and let me know if there are any issues or further changes needed.