### PR TITLE
Fix lora split #297

### DIFF
--- a/exporter.py
+++ b/exporter.py
@@ -39,9 +39,11 @@ def apply_lora(model: torch.nn.Module, lora_path: str, inputs: Tuple[torch.Tenso
         error(e)
         error("LoRA not found. Please install LoRA extension first from ...")
     model.forward(*inputs)
-    lora_name = os.path.splitext(os.path.basename(lora_path))[0]
+    # it will split the lora file name have dot mean(already clean the filename extension)
+    # lora_name = os.path.splitext(os.path.basename(lora_path))[0]
+    # so the lora_name will be the same as the lora_path
     networks.load_networks(
-        [lora_name], [1.0], [1.0], [None]
+        [lora_path], [1.0], [1.0], [None]
     )
 
     model.forward(*inputs)
@@ -105,6 +107,8 @@ def export_lora(
         [weights_name_mapping, weights_shape_mapping] = json.load(fp_wts)
 
     with torch.inference_mode(), torch.autocast("cuda"):
+        # print(f"[Yomisana] Exporting to ONNX: \nonnx_path:{onnx_path} \nweights_map_path:{weights_map_path} \nlora_name:{lora_name} \nprofile:{profile}")
+        # print(f"[Yomisana] brother ewww:{os.path.splitext(lora_name)[0]}\ninputs:{inputs}")
         modelobj.unet = apply_lora(
             modelobj.unet, os.path.splitext(lora_name)[0], inputs
         )

--- a/scripts/lora.py
+++ b/scripts/lora.py
@@ -14,7 +14,7 @@ def merge_loras(loras: List[str], scales: List[str]) -> dict:
     lora_names = [os.path.splitext(os.path.basename(lora))[0] for lora in loras] # only output the file name
     for lora, scale, lora_name in zip(loras, scales, lora_names):
         lora_dict = load_file(lora)
-        with tqdm(total=len(lora_dict), desc=f" > Loading '{lora_name}' LoRA") as pbar:
+        with tqdm(total=len(lora_dict), desc=f" > Loading '{lora_name}' LoRA", mininterval=1) as pbar:
             for k, v in lora_dict.items():
                 if k in refit_dict:
                     refit_dict[k] += scale * v
@@ -39,7 +39,7 @@ def apply_loras(base_path: str, loras: List[str], scales: List[str]) -> dict:
             return np.array([np.int32(arr)])
         return arr
     total_initializers = sum(1 for initializer in base.graph.initializer if initializer.name in refit_dict)
-    with tqdm(total=total_initializers, desc="Updating weights") as pbar:
+    with tqdm(total=total_initializers, desc="Updating weights", mininterval=1) as pbar:
         for initializer in base.graph.initializer:
             if initializer.name not in refit_dict:
                 continue

--- a/scripts/lora.py
+++ b/scripts/lora.py
@@ -6,40 +6,53 @@ import torch
 from safetensors.torch import load_file
 import onnx
 from onnx import numpy_helper
-
+from tqdm import tqdm
 
 def merge_loras(loras: List[str], scales: List[str]) -> dict:
     refit_dict = {}
-    for lora, scale in zip(loras, scales):
+    # total_files = len(loras)
+    lora_names = [os.path.splitext(os.path.basename(lora))[0] for lora in loras] # only output the file name
+    for lora, scale, lora_name in zip(loras, scales, lora_names):
         lora_dict = load_file(lora)
-        for k, v in lora_dict.items():
-            if k in refit_dict:
-                refit_dict[k] += scale * v
-            else:
-                refit_dict[k] = scale * v
+        with tqdm(total=len(lora_dict), desc=f" > Loading '{lora_name}' LoRA") as pbar:
+            for k, v in lora_dict.items():
+                if k in refit_dict:
+                    refit_dict[k] += scale * v
+                else:
+                    refit_dict[k] = scale * v
+                pbar.update(1)
+                pbar.refresh()
+    print("[TensorRT] LoRA loading completed.")
     return refit_dict
 
 
 def apply_loras(base_path: str, loras: List[str], scales: List[str]) -> dict:
     refit_dict = merge_loras(loras, scales)
+    # apply base model from stable_diffusion_2080ti\models\Unet-onnx\owo_checkpoint.onnx for refit, lora: ['stable_diffusion_2080ti\\models\\Unet-trt\\owo_lora.lora']
+    base_name = os.path.basename(base_path)
+    lora_names = [os.path.basename(os.path.dirname(lora)) for lora in loras]
+    print(f"[TensorRT] apply base model from {base_name} for refit lora: {lora_names}")
     base = onnx.load(base_path)
     onnx_opt_dir = os.path.dirname(base_path)
-
     def convert_int64(arr):
         if len(arr.shape) == 0:
             return np.array([np.int32(arr)])
         return arr
+    total_initializers = sum(1 for initializer in base.graph.initializer if initializer.name in refit_dict)
+    with tqdm(total=total_initializers, desc="Updating weights") as pbar:
+        for initializer in base.graph.initializer:
+            if initializer.name not in refit_dict:
+                continue
 
-    for initializer in base.graph.initializer:
-        if initializer.name not in refit_dict:
-            continue
+            wt = refit_dict[initializer.name]
+            initializer_data = numpy_helper.to_array(
+                initializer, base_dir=onnx_opt_dir
+            ).astype(np.float16)
+            delta = torch.tensor(initializer_data).to(wt.device) + wt
 
-        wt = refit_dict[initializer.name]
-        initializer_data = numpy_helper.to_array(
-            initializer, base_dir=onnx_opt_dir
-        ).astype(np.float16)
-        delta = torch.tensor(initializer_data).to(wt.device) + wt
+            refit_dict[initializer.name] = delta.contiguous()
 
-        refit_dict[initializer.name] = delta.contiguous()
-
+            pbar.update(1)
+            pbar.refresh()
+    print("[TensorRT] LoRA apply completed.")
     return refit_dict

--- a/scripts/trt.py
+++ b/scripts/trt.py
@@ -220,7 +220,7 @@ class TensorRTScript(scripts.Script):
             return
 
         # Get pathes
-        print("Apllying LoRAs: " + str(loras))
+        print("[TensorRT] Apllying LoRAs: " + str(loras))
         available = modelmanager.available_loras()
         for lora in loras:
             lora_name, lora_scale = lora.split(":")[1:]

--- a/ui_trt.py
+++ b/ui_trt.py
@@ -157,11 +157,27 @@ def export_unet_to_trt(
     return "## Exported Successfully \n"
 
 
+def process_lora_name(lora_name):
+    last_left_bracket_index = lora_name.rfind('(')
+    
+    if last_left_bracket_index != -1:
+        version_info = lora_name[last_left_bracket_index:]
+        # fix file name with space on the end
+        lora_name = lora_name[:last_left_bracket_index - 1]
+        return lora_name, version_info
+    else:
+        # if can't find left "("" will not change anything)
+        return lora_name, ''
+
 def export_lora_to_trt(lora_name, force_export):
     is_xl = shared.sd_model.is_sdxl
 
     available_lora_models = get_lora_checkpoints()
-    lora_name = lora_name.split(" ")[0]
+    # old code of get lora_name
+    # lora_name = lora_name.split(" ")[0]
+    # Fix lora_name with space
+    lora_name, version_info = process_lora_name(lora_name) # it also have fixed on the end space of lora_name
+
     lora_model = available_lora_models.get(lora_name, None)
     if lora_model is None:
         return f"## No LoRA model found for {lora_name}"

--- a/ui_trt.py
+++ b/ui_trt.py
@@ -153,7 +153,7 @@ def export_unet_to_trt(
 
     gc.collect()
     torch.cuda.empty_cache()
-
+    print("[TensorRT] Exported Successfully")
     return "## Exported Successfully \n"
 
 
@@ -224,7 +224,7 @@ def export_lora_to_trt(lora_name, force_export):
 
     if os.path.exists(lora_trt_path) and not force_export:
         print(
-            "TensorRT engine found. Skipping build. You can enable Force Export in the Advanced Settings to force a rebuild if needed."
+            "[TensorRT] engine found. Skipping build. You can enable Force Export in the Advanced Settings to force a rebuild if needed."
         )
         return "## Exported Successfully \n"
 
@@ -239,7 +239,7 @@ def export_lora_to_trt(lora_name, force_export):
 
     save_file(refit_dict, lora_trt_path)
 
-
+    print("[TensorRT] Exported Successfully")
     return "## Exported Successfully \n"
 
 

--- a/ui_trt.py
+++ b/ui_trt.py
@@ -282,7 +282,7 @@ def get_lora_checkpoints():
 
         base_model = metadata.get("ss_sd_model_name", "Unknown")
         if os.path.exists(config_file):
-            with open(config_file, "r") as f:
+            with open(config_file, "r", encoding="utf-8") as f:
                 config = json.load(f)
             try:
                 version = SDVersion.from_str(config["sd version"])


### PR DESCRIPTION
- Fix #297 using find the rightmost left bracket "(" 
- Fix #297 multi dot filename can't find issue.(if keep load multi dot and that file it self export have error is not on this issue)
- Fix load json of 'cp950'...etc codec can't decode issue
- Prevent file names from having multiple spaces that may be encountered(at file name end)