### PR TITLE
Fix UnicodeDecodeError: Ensure UTF-8 encoding when reading JSON config

### DIFF
--- a/ui_trt.py
+++ b/ui_trt.py
@@ -266,7 +266,7 @@ def get_lora_checkpoints():
 
         base_model = metadata.get("ss_sd_model_name", "Unknown")
         if os.path.exists(config_file):
-            with open(config_file, "r") as f:
+            with open(config_file, "r", encoding="utf-8") as f:
                 config = json.load(f)
             try:
                 version = SDVersion.from_str(config["sd version"])


### PR DESCRIPTION
Fix UnicodeDecodeError: Ensure UTF-8 encoding when reading JSON config
### Problem
This error occurs when the script attempts to read LoRA configuration files (or other related JSON files) that contain special characters outside of the default encoding (CP1252 on Windows). If the file includes characters not supported by this encoding, Python throws the following error:

`UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 1011: character maps to <undefined>`

### Cause
By default, Python’s `open()` function reads files using the system's default encoding, which on Windows is often `cp1252`. If the file is actually encoded in UTF-8 and contains special characters, this leads to a decoding failure.

### Solution
The fix enforces UTF-8 encoding when opening JSON config files, ensuring compatibility with special characters. This is done by modifying:

```
with open(config_file, "r") as f:
    config = json.load(f)
```

To:

```
with open(config_file, "r", encoding="utf-8") as f:
    config = json.load(f)
```

This change ensures that the script correctly handles files with Unicode characters, preventing crashes due to encoding mismatches.

Closes #239 